### PR TITLE
NGINX Plus R33 related fixes

### DIFF
--- a/ngxunprivinst.sh
+++ b/ngxunprivinst.sh
@@ -103,26 +103,28 @@ fi
 ARCH=x86_64
 [ `uname -m` = "aarch64" ] && ARCH=aarch64
 
+[ -z $REPOPREFIX ] && REPOPREFIX=https://pkgs.nginx.com/plus
+
 if [ -f /etc/redhat-release ]; then
     RELEASE=`grep -Eo 'release [0-9]{1}' /etc/redhat-release | cut -d' ' -f2`
-    REPOURL=https://pkgs.nginx.com/plus/centos/$RELEASE/$ARCH/RPMS/
+    REPOURL=$REPOPREFIX/centos/$RELEASE/$ARCH/RPMS/
     DISTRO="RHEL/CentOS"
     SUFFIX="el"
 elif [ -f /etc/os-release ] && fgrep SLES /etc/os-release; then
     RELEASE=`grep -Eo 'VERSION="[0-9]{2}' /etc/os-release | cut -d'"' -f2`
-    REPOURL=https://pkgs.nginx.com/plus/sles/$RELEASE/$ARCH/RPMS/
+    REPOURL=$REPOPREFIX/sles/$RELEASE/$ARCH/RPMS/
     DISTRO="SLES"
     SUFFIX="sles"
 elif [ -f /etc/os-release ] && fgrep -q -i amazon /etc/os-release; then
     RELEASE=`grep -Eo 'VERSION=".+"' /etc/os-release | cut -d'"' -f2`
     if [ "$RELEASE" = "2" ]; then
-        REPOURL=https://pkgs.nginx.com/plus/amzn2/2/$ARCH/RPMS/
+        REPOURL=$REPOPREFIX/amzn2/2/$ARCH/RPMS/
         SUFFIX="amzn2"
     elif [ "$RELEASE" = "2023" ]; then
-        REPOURL=https://pkgs.nginx.com/plus/amzn/2023/$ARCH/RPMS/
+        REPOURL=$REPOPREFIX/amzn/2023/$ARCH/RPMS/
         SUFFIX="amzn2023"
     else
-        REPOURL=https://pkgs.nginx.com/plus/amzn/latest/$ARCH/RPMS/
+        REPOURL=$REPOPREFIX/amzn/latest/$ARCH/RPMS/
         SUFFIX="amzn1"
         RELEASE="1"
     fi
@@ -132,10 +134,10 @@ elif [ -f /usr/bin/dpkg ]; then
     [ `uname -m` = "aarch64" ] && ARCH=arm64
     DISTRO=`grep -E "^ID=" /etc/os-release | cut -d '=' -f2 | tr '[:upper:]' '[:lower:]'`
     RELEASE=`grep VERSION_CODENAME /etc/os-release | cut -d '=' -f2`
-    REPOURL=https://pkgs.nginx.com/plus/$DISTRO/pool/nginx-plus/n/
+    REPOURL=$REPOPREFIX/$DISTRO/pool/nginx-plus/n/
 elif [ -x /sbin/apk ]; then
     RELEASE=`grep -Eo 'VERSION_ID=[0-9]\.[0-9]{1,2}' /etc/os-release | cut -d'=' -f2`
-    REPOURL=https://pkgs.nginx.com/plus/alpine/v$RELEASE/main/$ARCH/
+    REPOURL=$REPOPREFIX/alpine/v$RELEASE/main/$ARCH/
     DISTRO="alpine"
 else
     echo "Cannot determine your operating system."
@@ -152,7 +154,7 @@ if [ "$ACTION" = 'fetch' ] || [ "$ACTION" = 'list' ]; then
         ldd $(which wget) | grep -q libgnutls || \
             echo "" | openssl s_client -servername pkgs.nginx.com -cert $NGXCERT -key $NGXKEY -connect pkgs.nginx.com:443 >/dev/null 2>&1 || \
             WGET='wget -q --ciphers DEFAULT@SECLEVEL=1'
-            if ! $WGET -O /dev/null --certificate=$NGXCERT --private-key=$NGXKEY https://pkgs.nginx.com/plus/ ; then
+            if ! $WGET -O /dev/null --certificate=$NGXCERT --private-key=$NGXKEY $REPOPREFIX/ ; then
                 echo "Cannot connect to pkgs.nginx.com, please check certificate and key."
                 exit 1
             fi
@@ -409,7 +411,7 @@ upgrade() {
 
 list() {
     if [ "$DISTRO" = 'ubuntu' ] || [ "$DISTRO" = 'debian' ]; then
-        REPOURL=https://pkgs.nginx.com/plus/$DISTRO/pool/nginx-plus/n/nginx-plus
+        REPOURL=$REPOPREFIX/$DISTRO/pool/nginx-plus/n/nginx-plus
     fi
     echo "Versions available for $DISTRO $RELEASE $ARCH:"
     if [ "$DISTRO" = 'alpine' ] ; then


### PR DESCRIPTION
NGINX Plus R33 introduces a need to place license_token on a filesystem.  Those changes make sure the file is propagated to the installation directory.